### PR TITLE
Don't include AttributeStatement if nil or empty

### DIFF
--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -58,7 +58,7 @@ module SamlIdp
                   end
               end
             end
-          end
+          end unless config.attributes.nil? || config.attributes.empty?
           assertion.AuthnStatement AuthnInstant: now_iso, SessionIndex: reference_string do |statement|
             statement.AuthnContext do |context|
               context.AuthnContextClassRef Saml::XML::Namespaces::AuthnContext::ClassRef::PASSWORD


### PR DESCRIPTION
SAML provider was unable to parse the response if attributes were empty. This removes the AttributeStatement if no attributes are specified