### PR TITLE
Enable overriding of AuthnContextClassRef in the SamlIdp::Controller.

### DIFF
--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -12,10 +12,11 @@ module SamlIdp
     attr_accessor :saml_request_id
     attr_accessor :saml_acs_url
     attr_accessor :raw_algorithm
+    attr_accessor :authn_context_classref
 
     delegate :config, to: :SamlIdp
 
-    def initialize(reference_id, issuer_uri, principal, audience_uri, saml_request_id, saml_acs_url, raw_algorithm)
+    def initialize(reference_id, issuer_uri, principal, audience_uri, saml_request_id, saml_acs_url, raw_algorithm, authn_context_classref)
       self.reference_id = reference_id
       self.issuer_uri = issuer_uri
       self.principal = principal
@@ -23,6 +24,7 @@ module SamlIdp
       self.saml_request_id = saml_request_id
       self.saml_acs_url = saml_acs_url
       self.raw_algorithm = raw_algorithm
+      self.authn_context_classref = authn_context_classref
     end
 
     def fresh
@@ -61,7 +63,7 @@ module SamlIdp
           end
           assertion.AuthnStatement AuthnInstant: now_iso, SessionIndex: reference_string do |statement|
             statement.AuthnContext do |context|
-              context.AuthnContextClassRef Saml::XML::Namespaces::AuthnContext::ClassRef::PASSWORD
+              context.AuthnContextClassRef authn_context_classref
             end
           end
         end

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -26,6 +26,10 @@ module SamlIdp
       self.saml_request = Request.from_deflated_request(raw_saml_request)
     end
 
+    def authn_context_classref
+      Saml::XML::Namespaces::AuthnContext::ClassRef::PASSWORD
+    end
+
     def encode_response(principal, opts = {})
       response_id, reference_id = get_saml_response_id, get_saml_reference_id
       audience_uri = opts[:audience_uri] || saml_request.issuer || saml_acs_url[/^(.*?\/\/.*?\/)/, 1]
@@ -39,7 +43,8 @@ module SamlIdp
         audience_uri,
         saml_request_id,
         saml_acs_url,
-        algorithm
+        algorithm,
+        authn_context_classref
       ).build
     end
 

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -13,6 +13,7 @@ module SamlIdp
     attr_accessor :algorithm
     attr_accessor :secret_key
     attr_accessor :x509_certificate
+    attr_accessor :authn_context_classref
 
     def initialize(reference_id,
           response_id,
@@ -21,7 +22,8 @@ module SamlIdp
           audience_uri,
           saml_request_id,
           saml_acs_url,
-          algorithm
+          algorithm,
+          authn_context_classref
           )
       self.reference_id = reference_id
       self.response_id = response_id
@@ -33,6 +35,7 @@ module SamlIdp
       self.algorithm = algorithm
       self.secret_key = secret_key
       self.x509_certificate = x509_certificate
+      self.authn_context_classref = authn_context_classref
     end
 
     def build
@@ -56,7 +59,8 @@ module SamlIdp
         audience_uri,
         saml_request_id,
         saml_acs_url,
-        algorithm
+        algorithm,
+        authn_context_classref
     end
     private :assertion_builder
   end

--- a/spec/lib/saml_idp/assertion_builder_spec.rb
+++ b/spec/lib/saml_idp/assertion_builder_spec.rb
@@ -8,6 +8,9 @@ module SamlIdp
     let(:saml_request_id) { "123" }
     let(:saml_acs_url) { "http://saml.acs.url" }
     let(:algorithm) { :sha256 }
+    let(:authn_context_classref) {
+      Saml::XML::Namespaces::AuthnContext::ClassRef::PASSWORD
+    }
     subject { described_class.new(
       reference_id,
       issuer_uri,
@@ -15,7 +18,8 @@ module SamlIdp
       audience_uri,
       saml_request_id,
       saml_acs_url,
-      algorithm
+      algorithm,
+      authn_context_classref
     ) }
 
     it "builds a legit raw XML file" do

--- a/spec/lib/saml_idp/saml_response_spec.rb
+++ b/spec/lib/saml_idp/saml_response_spec.rb
@@ -11,6 +11,10 @@ module SamlIdp
     let(:algorithm) { :sha1 }
     let(:secret_key) { Default::SECRET_KEY }
     let(:x509_certificate) { Default::X509_CERTIFICATE }
+    let(:xauthn) { Default::X509_CERTIFICATE }
+    let(:authn_context_classref) {
+      Saml::XML::Namespaces::AuthnContext::ClassRef::PASSWORD
+    }
     subject { described_class.new(reference_id,
                                   response_id,
                                   issuer_uri,
@@ -18,7 +22,8 @@ module SamlIdp
                                   audience_uri,
                                   saml_request_id,
                                   saml_acs_url,
-                                  algorithm
+                                  algorithm,
+                                  authn_context_classref
                                  )
     }
 


### PR DESCRIPTION
This makes sense because the AuthnContextClassRef can change
depending on the authentication level of the user which differs
per request.