### PR TITLE
Updates ruby-saml gem dependency to 0.8.1

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -70,7 +70,6 @@ module SamlIdp
     def authn_request
       xpath("//samlp:AuthnRequest", samlp: samlp).first
     end
-    private :authn_request
 
     def samlp
       Saml::XML::Namespaces::PROTOCOL

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -66,7 +66,6 @@ module SamlIdp
     def document
       @document ||= Saml::XML::Document.parse(raw_xml)
     end
-    private :document
 
     def authn_request
       xpath("//samlp:AuthnRequest", samlp: samlp).first

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "rspec", "~> 2.5"
-  s.add_development_dependency "ruby-saml", "~> 0.8"
+  s.add_development_dependency "ruby-saml", "~> 0.8.1"
   s.add_development_dependency("rails", "~> 3.2")
   s.add_development_dependency("capybara")
   s.add_development_dependency("timecop")

--- a/spec/support/responses/logoutresponse_fixtures.rb
+++ b/spec/support/responses/logoutresponse_fixtures.rb
@@ -52,7 +52,7 @@ def invalid_xml_response
 end
 
 def settings
-  @settings ||= Onelogin::Saml::Settings.new(
+  @settings ||= OneLogin::RubySaml::Settings.new(
       {
           :assertion_consumer_service_url => "http://app.muda.no/sso/consume",
           :assertion_consumer_logout_service_url => "http://app.muda.no/sso/consume_logout",


### PR DESCRIPTION
The [Ruby SAML gem](https://github.com/onelogin/ruby-saml) has breaking changes between 0.7.x and 0.8.x. 
In addition, version `0.8.0` is marked as broken.

Updates dependencies to Ruby SAML gem `0.8.1` 