### PR TITLE
add try method for "#issuer" call on saml_request

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -32,7 +32,7 @@ module SamlIdp
 
     def encode_response(principal, opts = {})
       response_id, reference_id = get_saml_response_id, get_saml_reference_id
-      audience_uri = opts[:audience_uri] || saml_request.issuer || saml_acs_url[/^(.*?\/\/.*?\/)/, 1]
+      audience_uri = opts[:audience_uri] || saml_request.try(:issuer) || saml_acs_url[/^(.*?\/\/.*?\/)/, 1]
       opt_issuer_uri = opts[:issuer_uri] || issuer_uri
 
       SamlResponse.new(


### PR DESCRIPTION
Currently implementing IDP initiated SSO and setting `saml_acs_url` manually. In this case, saml_request will be nil though and throws `NoMethodError` before reaching `saml_acs_url`. 

Another option could be putting `saml_acs_url` ahead of `saml_request.issuer`. 