### PR TITLE
Fixes issues when SAMLRequest is nil or invalid.

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -13,6 +13,8 @@ module SamlIdp
           end
         rescue Zlib::DataError # not compressed
           inflated = decoded
+        rescue Zlib::BufError  # invalid
+          inflated = ""
         end
       else
         inflated = ""

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -39,7 +39,7 @@ module SamlIdp
 
     def acs_url
       service_provider.acs_url ||
-        authn_request["AssertionConsumerServiceURL"].to_s
+        authn_request.try(:[], :AssertionConsumerServiceURL).to_s
     end
 
     def valid?

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -1,32 +1,46 @@
 require 'spec_helper'
 module SamlIdp
   describe Request do
-    let(:raw_request) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/></samlp:AuthnRequest>" }
-    subject { described_class.new raw_request }
+    describe "with an inflated and valid SAML request" do
+      let(:raw_request) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/></samlp:AuthnRequest>" }
+      subject { described_class.new raw_request }
 
-    it "has a valid request_id" do
-      subject.request_id.should == "_af43d1a0-e111-0130-661a-3c0754403fdb"
+      it "has a valid request_id" do
+        subject.request_id.should == "_af43d1a0-e111-0130-661a-3c0754403fdb"
+      end
+
+      it "has a valid acs_url" do
+        subject.acs_url.should == "http://localhost:3000/saml/consume"
+      end
+
+      it "has a valid service_provider" do
+        subject.service_provider.should be_a ServiceProvider
+      end
+
+      it "has a valid service_provider" do
+        subject.service_provider.should be_truthy
+      end
+
+      it "has a valid issuer" do
+        subject.issuer.should == "localhost:3000"
+      end
+
+      it "has a valid valid_signature" do
+        subject.valid_signature?.should be_truthy
+      end
     end
 
-    it "has a valid acs_url" do
-      subject.acs_url.should == "http://localhost:3000/saml/consume"
+    describe "with an inflated but invalid SAML request" do
+      it "returns an empty string when " do
+        described_class.new "<samlp:AuthnRequest></samlp:AuthnRequest>"
+        subject.acs_url == ""
+      end
     end
 
-    it "has a valid service_provider" do
-      subject.service_provider.should be_a ServiceProvider
+    describe "with an improperly deflated SAML request" do
+      it "rescues Zlib::BufError exceptions" do
+        expect { described_class.from_deflated_request nil }.to_not raise_error
+      end
     end
-
-    it "has a valid service_provider" do
-      subject.service_provider.should be_truthy
-    end
-
-    it "has a valid issuer" do
-      subject.issuer.should == "localhost:3000"
-    end
-
-    it "has a valid valid_signature" do
-      subject.valid_signature?.should be_truthy
-    end
-
   end
 end


### PR DESCRIPTION
When `SAMLRequest` is not valid, Zlib throws a `Zlib::BufError` which isn't handled and when it's `nil` (i.e. not submitted by the user), `acs_url` assumes `authn_request` is a hash which is not always the case.