### PR TITLE
Update saml_idp.gemspec nokogiri dependency

### DIFF
--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -40,7 +40,7 @@ defaults in a Production environment. Post any issues you to github.
   s.add_dependency('uuid')
   s.add_dependency('builder')
   s.add_dependency('httparty')
-  s.add_dependency('nokogiri')
+  s.add_dependency('nokogiri', '>= 1.6.2')
 
   s.add_development_dependency "rake"
   s.add_development_dependency "simplecov"


### PR DESCRIPTION
Add '>= 1.6.2' dependency for nokogiri. Version 1.6.1 and below causes saml_idp to create invalid saml responses. This can be seen easily as all validations in the saml_idp_controller_spec will fail with nokogiri 1.6.1 and below.