### PR TITLE
Change order of AuthnStatement and AttributeStatement for lasso

### DIFF
--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -50,6 +50,11 @@ module SamlIdp
               restriction.Audience audience_uri
             end
           end
+          assertion.AuthnStatement AuthnInstant: now_iso, SessionIndex: reference_string do |statement|
+            statement.AuthnContext do |context|
+              context.AuthnContextClassRef authn_context_classref
+            end
+          end
           assertion.AttributeStatement do |attr_statement|
             config.attributes.each do |friendly_name, attrs|
               attrs = (attrs || {}).with_indifferent_access
@@ -61,11 +66,6 @@ module SamlIdp
                     attr.AttributeValue val.to_s
                   end
               end
-            end
-          end
-          assertion.AuthnStatement AuthnInstant: now_iso, SessionIndex: reference_string do |statement|
-            statement.AuthnContext do |context|
-              context.AuthnContextClassRef authn_context_classref
             end
           end
         end


### PR DESCRIPTION
This makes the assertions generated by saml_idp compatible with liblasso and the Apache mod_auth_mellon module. liblasso only accepts SAML response that have the AuthnStatement before the AttributeStatement. As far as I can tell, this is a bug in lasso and I will report it to them. In the meantime, and especially until a future version of lasso is released and then rolled into the various Linux distributions, this PR restores compatibility with mod_auth_mellon. I have not tested these changes with any other SP.

Even if this PR is not accepted it may help someone googling for saml_idp and mod_auth_mellon.
