### PR TITLE
Add support for SLO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ notifications:
        - jon.phenow@sportngin.com
     on_success: change
     on_failure: always
+sudo: false

--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -71,11 +71,11 @@ module Saml
 
       def valid_signature?(fingerprint)
         signed? &&
-          signed_document.validate_document(fingerprint, :soft)
+          signed_document.validate(fingerprint, :soft)
       end
 
       def signed_document
-        XMLSecurity::SignedDocument.new(to_xml)
+        SamlIdp::XMLSecurity::SignedDocument.new(to_xml)
       end
 
       def signature_namespace

--- a/lib/saml_idp/configurator.rb
+++ b/lib/saml_idp/configurator.rb
@@ -13,6 +13,7 @@ module SamlIdp
     attr_accessor :reference_id_generator
     attr_accessor :attribute_service_location
     attr_accessor :single_service_post_location
+    attr_accessor :single_logout_service_post_location
     attr_accessor :attributes
     attr_accessor :service_provider
 

--- a/lib/saml_idp/logout_builder.rb
+++ b/lib/saml_idp/logout_builder.rb
@@ -4,10 +4,6 @@ module SamlIdp
     include Signable
 
     # this is an abstract base class.
-    def signature_opts
-      raise "#{self.class} must implement signature_opts method"
-    end
-
     def build
       raise "#{self.class} must implement build method"
     end
@@ -18,10 +14,6 @@ module SamlIdp
 
     def digest
       algorithm.hexdigest raw
-    end
-
-    def algorithm
-      signature_opts[:algorithm] || OpenSSL::Digest::SHA256
     end
 
     def encoded

--- a/lib/saml_idp/logout_builder.rb
+++ b/lib/saml_idp/logout_builder.rb
@@ -13,7 +13,7 @@ module SamlIdp
     end
 
     def reference_id
-      signature_opts[:reference_id] || UUID.generate
+      UUID.generate
     end
 
     def digest

--- a/lib/saml_idp/logout_builder.rb
+++ b/lib/saml_idp/logout_builder.rb
@@ -1,0 +1,50 @@
+require 'builder'
+module SamlIdp
+  class LogoutBuilder
+    include Signable
+
+    # this is an abstract base class.
+    def signature_opts
+      raise "#{self.class} must implement signature_opts method"
+    end
+
+    def build
+      raise "#{self.class} must implement build method"
+    end
+
+    def reference_id
+      signature_opts[:reference_id] || UUID.generate
+    end
+
+    def digest
+      algorithm.hexdigest raw
+    end
+
+    def algorithm
+      signature_opts[:algorithm] || OpenSSL::Digest::SHA256
+    end
+
+    def encoded
+      @encoded ||= encode
+    end 
+
+    def raw 
+      build
+    end 
+
+    def encode
+      Base64.strict_encode64(raw)
+    end 
+    private :encode
+
+    def response_id_string
+      "_#{response_id}"
+    end 
+    private :response_id_string
+
+    def now_iso
+      Time.now.utc.iso8601
+    end
+    private :now_iso
+  end
+end

--- a/lib/saml_idp/logout_request_builder.rb
+++ b/lib/saml_idp/logout_request_builder.rb
@@ -6,15 +6,15 @@ module SamlIdp
     attr_accessor :saml_slo_url
     attr_accessor :name_id
     attr_accessor :session_index
-    attr_accessor :signature_opts
+    attr_accessor :algorithm
 
-    def initialize(response_id, issuer_uri, saml_slo_url, name_id, session_index, signature_opts)
+    def initialize(response_id, issuer_uri, saml_slo_url, name_id, session_index, algorithm)
       self.response_id = response_id
       self.issuer_uri = issuer_uri
       self.saml_slo_url = saml_slo_url
       self.name_id = name_id
       self.session_index = session_index
-      self.signature_opts = signature_opts
+      self.algorithm = algorithm
     end
 
     def build

--- a/lib/saml_idp/logout_request_builder.rb
+++ b/lib/saml_idp/logout_request_builder.rb
@@ -1,0 +1,73 @@
+require 'builder'
+module SamlIdp
+  class LogoutRequestBuilder
+    include Signable
+
+    attr_accessor :response_id
+    attr_accessor :issuer_uri
+    attr_accessor :saml_slo_url
+    attr_accessor :name_id
+    attr_accessor :session_index
+    attr_accessor :signature_settings
+
+    def initialize(response_id, issuer_uri, saml_slo_url, name_id, session_index, signature_settings)
+      self.response_id = response_id
+      self.issuer_uri = issuer_uri
+      self.saml_slo_url = saml_slo_url
+      self.name_id = name_id
+      self.session_index = session_index
+      self.signature_settings = signature_settings
+    end
+
+    def reference_id
+      signature_settings[:reference_id] || UUID.generate
+    end
+
+    def digest
+      algorithm.hexdigest raw
+    end
+
+    def algorithm
+      signature_settings[:algorithm] || OpenSSL::Digest::SHA256
+    end
+
+    def encoded
+      @encoded ||= encode
+    end 
+
+    def raw 
+      build
+    end 
+
+    def encode
+      Base64.strict_encode64(raw)
+    end 
+    private :encode
+
+    def response_id_string
+      "_#{response_id}"
+    end 
+    private :response_id_string
+
+    def build
+      builder = Builder::XmlMarkup.new
+      builder.LogoutRequest ID: response_id_string,
+        Version: "2.0",
+        IssueInstant: now_iso,
+        Destination: saml_slo_url,
+        "xmlns" => Saml::XML::Namespaces::PROTOCOL do |request|
+          request.Issuer issuer_uri, xmlns: Saml::XML::Namespaces::ASSERTION
+          sign request
+          request.NameID name_id, xmlns: Saml::XML::Namespaces::ASSERTION,
+            Format: Saml::XML::Namespaces::Formats::NameId::PERSISTENT
+          request.SessionIndex session_index
+        end
+    end
+    private :build
+
+    def now_iso
+      Time.now.utc.iso8601
+    end
+    private :now_iso
+  end
+end

--- a/lib/saml_idp/logout_request_builder.rb
+++ b/lib/saml_idp/logout_request_builder.rb
@@ -1,53 +1,21 @@
-require 'builder'
+require 'saml_idp/logout_builder'
 module SamlIdp
-  class LogoutRequestBuilder
-    include Signable
-
+  class LogoutRequestBuilder < LogoutBuilder
     attr_accessor :response_id
     attr_accessor :issuer_uri
     attr_accessor :saml_slo_url
     attr_accessor :name_id
     attr_accessor :session_index
-    attr_accessor :signature_settings
+    attr_accessor :signature_opts
 
-    def initialize(response_id, issuer_uri, saml_slo_url, name_id, session_index, signature_settings)
+    def initialize(response_id, issuer_uri, saml_slo_url, name_id, session_index, signature_opts)
       self.response_id = response_id
       self.issuer_uri = issuer_uri
       self.saml_slo_url = saml_slo_url
       self.name_id = name_id
       self.session_index = session_index
-      self.signature_settings = signature_settings
+      self.signature_opts = signature_opts
     end
-
-    def reference_id
-      signature_settings[:reference_id] || UUID.generate
-    end
-
-    def digest
-      algorithm.hexdigest raw
-    end
-
-    def algorithm
-      signature_settings[:algorithm] || OpenSSL::Digest::SHA256
-    end
-
-    def encoded
-      @encoded ||= encode
-    end 
-
-    def raw 
-      build
-    end 
-
-    def encode
-      Base64.strict_encode64(raw)
-    end 
-    private :encode
-
-    def response_id_string
-      "_#{response_id}"
-    end 
-    private :response_id_string
 
     def build
       builder = Builder::XmlMarkup.new
@@ -64,10 +32,5 @@ module SamlIdp
         end
     end
     private :build
-
-    def now_iso
-      Time.now.utc.iso8601
-    end
-    private :now_iso
   end
 end

--- a/lib/saml_idp/logout_response_builder.rb
+++ b/lib/saml_idp/logout_response_builder.rb
@@ -1,0 +1,35 @@
+require 'saml_idp/logout_builder'
+module SamlIdp
+  class LogoutResponseBuilder < LogoutBuilder
+    attr_accessor :response_id
+    attr_accessor :issuer_uri
+    attr_accessor :saml_slo_url
+    attr_accessor :saml_request_id
+    attr_accessor :signature_opts
+
+    def initialize(response_id, issuer_uri, saml_slo_url, saml_request_id, signature_opts)
+      @response_id = response_id
+      @issuer_uri = issuer_uri
+      @saml_slo_url = saml_slo_url
+      @saml_request_id = saml_request_id
+      @signature_opts = signature_opts
+    end 
+
+    def build
+      builder = Builder::XmlMarkup.new
+      builder.LogoutResponse ID: response_id_string,
+        Version: "2.0",
+        IssueInstant: now_iso,
+        Destination: saml_slo_url,
+        InResponseTo: saml_request_id,
+        xmlns: Saml::XML::Namespaces::PROTOCOL do |response|
+          response.Issuer issuer_uri, xmlns: Saml::XML::Namespaces::ASSERTION
+          sign response
+          response.Status xmlns: Saml::XML::Namespaces::PROTOCOL do |status|
+            status.StatusCode Value: Saml::XML::Namespaces::Statuses::SUCCESS 
+          end 
+        end 
+    end
+    private :build
+  end
+end

--- a/lib/saml_idp/logout_response_builder.rb
+++ b/lib/saml_idp/logout_response_builder.rb
@@ -5,14 +5,14 @@ module SamlIdp
     attr_accessor :issuer_uri
     attr_accessor :saml_slo_url
     attr_accessor :saml_request_id
-    attr_accessor :signature_opts
+    attr_accessor :algorithm
 
-    def initialize(response_id, issuer_uri, saml_slo_url, saml_request_id, signature_opts)
-      @response_id = response_id
-      @issuer_uri = issuer_uri
-      @saml_slo_url = saml_slo_url
-      @saml_request_id = saml_request_id
-      @signature_opts = signature_opts
+    def initialize(response_id, issuer_uri, saml_slo_url, saml_request_id, algorithm)
+      self.response_id = response_id
+      self.issuer_uri = issuer_uri
+      self.saml_slo_url = saml_slo_url
+      self.saml_request_id = saml_request_id
+      self.algorithm = algorithm
     end 
 
     def build

--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -146,6 +146,7 @@ module SamlIdp
       organization_url
       attribute_service_location
       single_service_post_location
+      single_logout_service_post_location
       technical_contact
     ].each do |delegatable|
       define_method(delegatable) do

--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -25,6 +25,8 @@ module SamlIdp
             entity.IDPSSODescriptor protocolSupportEnumeration: protocol_enumeration do |descriptor|
               build_key_descriptor descriptor
               build_name_id_formats descriptor
+              descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                Location: single_logout_service_post_location
               descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
                 Location: single_service_post_location
               build_attribute descriptor

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -31,8 +31,20 @@ module SamlIdp
       self.raw_xml = raw_xml
     end
 
+    def logout_request?
+      logout_request.nil? ? false : true
+    end
+
+    def authn_request?
+      authn_request.nil? ? false : true
+    end
+
     def request_id
-      authn_request["ID"]
+      if authn_request?
+        authn_request["ID"]
+      elsif logout_request?
+        logout_request["ID"]
+      end
     end
 
     def acs_url
@@ -40,14 +52,56 @@ module SamlIdp
         authn_request["AssertionConsumerServiceURL"].to_s
     end
 
+    def logout_url
+      service_provider.assertion_consumer_logout_service_url
+    end
+
+    def response_url
+      if authn_request?
+        acs_url
+      elsif logout_request?
+        logout_url
+      end
+    end
+
+    def logger(msg)
+      if Rails && Rails.logger
+        Rails.logger.info msg
+      else
+        puts msg
+      end
+    end
+
     def valid?
-      service_provider? &&
-        valid_signature? &&
-        acs_url.present?
+      # TODO: This should validate against the schema.
+
+      unless service_provider?
+        logger "Unable to find service provider for issuer #{issuer}"
+        return false
+      end
+
+      unless (authn_request? ^ logout_request?)
+        logger "One and only one of authnrequest and logout request is required. authnrequest: #{authn_request?} logout_request: #{logout_request?} "
+        return false
+      end
+
+      unless valid_signature?
+        logger "Signature is invalid in #{raw_xml}"
+        return false
+      end
+
+      if response_url.nil?
+        logger "Unable to find response url for #{issuer}: #{raw_xml}"
+        return false
+      end
+
+      return true
     end
 
     def valid_signature?
-      service_provider.valid_signature? document
+      # Force signatures for logout requests because there is no other
+      # protection against a cross-site DoS.
+      service_provider.valid_signature?(document, logout_request?)
     end
 
     def service_provider?
@@ -63,6 +117,10 @@ module SamlIdp
       @content if @content.present?
     end
 
+    def name_id
+      @name_id ||= xpath("//saml:NameID", saml: Saml::XML::Namespaces::ASSERTION).first.try(:content)
+    end
+
     def document
       @document ||= Saml::XML::Document.parse(raw_xml)
     end
@@ -72,6 +130,11 @@ module SamlIdp
       xpath("//samlp:AuthnRequest", samlp: samlp).first
     end
     private :authn_request
+
+    def logout_request
+      xpath("//samlp:LogoutRequest", samlp: samlp).first
+    end
+    private :logout_request
 
     def samlp
       Saml::XML::Namespaces::PROTOCOL

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -117,16 +117,15 @@ module SamlIdp
     end
 
     def service_provider
-      @service_provider ||= ServiceProvider.new((service_provider_finder[issuer] || {}).merge(identifier: issuer))
+      @_service_provider ||= ServiceProvider.new((service_provider_finder[issuer] || {}).merge(identifier: issuer))
     end
 
     def issuer
-      @content ||= xpath("//saml:Issuer", saml: assertion).first.try(:content)
-      @content if @content.present?
+      @_issuer ||= xpath("//saml:Issuer", saml: assertion).first.try(:content)
     end
 
     def name_id
-      @name_id ||= xpath("//saml:NameID", saml: assertion).first.try(:content)
+      @_name_id ||= xpath("//saml:NameID", saml: assertion).first.try(:content)
     end
 
     def session_index
@@ -134,24 +133,24 @@ module SamlIdp
     end
 
     def document
-      @document ||= Saml::XML::Document.parse(raw_xml)
+      @_document ||= Saml::XML::Document.parse(raw_xml)
     end
     private :document
 
     def authn_context_node
-      xpath("//samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef",
+      @_authn_context_node ||= xpath("//samlp:AuthnRequest/samlp:RequestedAuthnContext/saml:AuthnContextClassRef",
         samlp: samlp,
         saml: assertion).first
     end
     private :authn_context_node
 
     def authn_request
-      xpath("//samlp:AuthnRequest", samlp: samlp).first
+      @_authn_request ||= xpath("//samlp:AuthnRequest", samlp: samlp).first
     end
     private :authn_request
 
     def logout_request
-      xpath("//samlp:LogoutRequest", samlp: samlp).first
+      @_logout_request ||= xpath("//samlp:LogoutRequest", samlp: samlp).first
     end
     private :logout_request
 

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -40,10 +40,14 @@ module SamlIdp
     end
 
     def request_id
+      request["ID"]
+    end
+
+    def request
       if authn_request?
-        authn_request["ID"]
+        authn_request
       elsif logout_request?
-        logout_request["ID"]
+        logout_request
       end
     end
 
@@ -72,7 +76,7 @@ module SamlIdp
       end
     end
 
-    def logger(msg)
+    def log(msg)
       if Rails && Rails.logger
         Rails.logger.info msg
       else
@@ -81,25 +85,23 @@ module SamlIdp
     end
 
     def valid?
-      # TODO: This should validate against the schema.
-
       unless service_provider?
-        logger "Unable to find service provider for issuer #{issuer}"
+        log "Unable to find service provider for issuer #{issuer}"
         return false
       end
 
       unless (authn_request? ^ logout_request?)
-        logger "One and only one of authnrequest and logout request is required. authnrequest: #{authn_request?} logout_request: #{logout_request?} "
+        log "One and only one of authnrequest and logout request is required. authnrequest: #{authn_request?} logout_request: #{logout_request?} "
         return false
       end
 
       unless valid_signature?
-        logger "Signature is invalid in #{raw_xml}"
+        log "Signature is invalid in #{raw_xml}"
         return false
       end
 
       if response_url.nil?
-        logger "Unable to find response url for #{issuer}: #{raw_xml}"
+        log "Unable to find response url for #{issuer}: #{raw_xml}"
         return false
       end
 

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -124,6 +124,7 @@ module SamlIdp
 
     def issuer
       @_issuer ||= xpath("//saml:Issuer", saml: assertion).first.try(:content)
+      @_issuer if @_issuer.present?
     end
 
     def name_id

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -126,7 +126,11 @@ module SamlIdp
     end
 
     def name_id
-      @name_id ||= xpath("//saml:NameID", saml: Saml::XML::Namespaces::ASSERTION).first.try(:content)
+      @name_id ||= xpath("//saml:NameID", saml: assertion).first.try(:content)
+    end
+
+    def session_index
+      @_session_index ||= xpath("//samlp:SessionIndex", samlp: samlp).first.try(:content)
     end
 
     def document

--- a/lib/saml_idp/response_builder.rb
+++ b/lib/saml_idp/response_builder.rb
@@ -24,7 +24,7 @@ module SamlIdp
     end
 
     def encode
-      Base64.encode64(raw)
+      Base64.strict_encode64(raw)
     end
     private :encode
 

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -6,6 +6,7 @@ module SamlIdp
   class ServiceProvider
     include Attributeable
     attribute :identifier
+    attribute :cert
     attribute :fingerprint
     attribute :metadata_url
     attribute :validate_signature
@@ -18,9 +19,12 @@ module SamlIdp
       attributes.present?
     end
 
-    def valid_signature?(doc)
-      !should_validate_signature? ||
+    def valid_signature?(doc, require_signature = false)
+      if require_signature || should_validate_signature?
         doc.valid_signature?(fingerprint)
+      else
+        true
+      end
     end
 
     def should_validate_signature?

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -10,6 +10,7 @@ module SamlIdp
     attribute :metadata_url
     attribute :validate_signature
     attribute :acs_url
+    attribute :assertion_consumer_logout_service_url
 
     delegate :config, to: :SamlIdp
 

--- a/lib/saml_idp/signable.rb
+++ b/lib/saml_idp/signable.rb
@@ -110,7 +110,7 @@ module SamlIdp
       digest_algorithm = get_algorithm
 
       hash                          = digest_algorithm.digest(canon_hashed_element)
-      Base64.encode64(hash).gsub(/\n/, '')
+      Base64.strict_encode64(hash).gsub(/\n/, '')
     end
     private :digest
 

--- a/lib/saml_idp/signed_info_builder.rb
+++ b/lib/saml_idp/signed_info_builder.rb
@@ -76,7 +76,7 @@ module SamlIdp
 
     def encoded
       key = OpenSSL::PKey::RSA.new(secret_key, password)
-      Base64.encode64(key.sign(algorithm.new, raw))
+      Base64.strict_encode64(key.sign(algorithm.new, raw))
     end
     private :encoded
 

--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -45,7 +45,7 @@ defaults in a Production environment. Post any issues you to github.
   s.add_development_dependency "rake"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "rspec", "~> 2.5"
-  s.add_development_dependency "ruby-saml", "~> 0.8"
+  s.add_development_dependency "ruby-saml", "~> 1.2"
   s.add_development_dependency("rails", "~> 3.2")
   s.add_development_dependency("capybara")
   s.add_development_dependency("timecop")

--- a/spec/lib/saml_idp/configurator_spec.rb
+++ b/spec/lib/saml_idp/configurator_spec.rb
@@ -10,6 +10,7 @@ module SamlIdp
     it { should respond_to :reference_id_generator }
     it { should respond_to :attribute_service_location }
     it { should respond_to :single_service_post_location }
+    it { should respond_to :single_logout_service_post_location }
     it { should respond_to :name_id }
     it { should respond_to :attributes }
     it { should respond_to :service_provider }

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -35,6 +35,16 @@ describe SamlIdp::Controller do
       response.is_valid?.should be_truthy
     end
 
+    it "should create a SAML Logout Response" do
+      params[:SAMLRequest] = make_saml_logout_request
+      validate_saml_request
+      expect(saml_request.logout_request?).to eq true
+      saml_response = encode_response(principal)
+      response = OneLogin::RubySaml::Logoutresponse.new(saml_response, saml_settings)
+      response.validate.should == true
+      response.issuer.should == "http://example.com"
+    end
+
     [:sha1, :sha256, :sha384, :sha512].each do |algorithm_name|
       it "should create a SAML Response using the #{algorithm_name} algorithm" do
         self.algorithm = algorithm_name

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -30,7 +30,7 @@ describe SamlIdp::Controller do
       saml_response = encode_response(principal)
       response = OneLogin::RubySaml::Response.new(saml_response)
       response.name_id.should == "foo@example.com"
-      response.issuer.should == "http://example.com"
+      response.issuers.first.should == "http://example.com"
       response.settings = saml_settings
       response.is_valid?.should be_truthy
     end
@@ -41,7 +41,7 @@ describe SamlIdp::Controller do
         saml_response = encode_response(principal)
         response = OneLogin::RubySaml::Response.new(saml_response)
         response.name_id.should == "foo@example.com"
-        response.issuer.should == "http://example.com"
+        response.issuers.first.should == "http://example.com"
         response.settings = saml_settings
         response.is_valid?.should be_truthy
       end

--- a/spec/lib/saml_idp/logout_request_builder_spec.rb
+++ b/spec/lib/saml_idp/logout_request_builder_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'saml_idp/logout_request_builder'
+
+module SamlIdp
+  describe LogoutRequestBuilder do
+    before do
+      Timecop.freeze(Time.local(1990))
+    end
+
+    after do
+      Timecop.return
+    end
+
+    let(:response_id) { 'some_response_id' }
+    let(:issuer_uri) { 'http://example.com' }
+    let(:saml_slo_url) { 'http://localhost:3000/saml/logout' }
+    let(:name_id) { 'some_name_id' }
+    let(:session_index) { 'abc123index' }
+    let(:assertion_opts) do
+      {
+        reference_id: SamlIdp.config.reference_id_generator.call,
+        audience_uri: 'example.com/audience',
+        algorithm: OpenSSL::Digest::SHA256
+      }
+    end 
+
+    subject do
+      described_class.new(
+        response_id,
+        issuer_uri,
+        saml_slo_url,
+        name_id,
+        session_index,
+        assertion_opts
+      )
+    end
+
+    it "is a valid SloLogoutrequest" do
+      Timecop.travel(Time.zone.local(2010, 6, 1, 13, 0, 0)) do
+        slo_request = OneLogin::RubySaml::SloLogoutrequest.new(
+          Base64.strict_encode64(subject.signed),
+          settings: saml_settings('localhost:3000')
+        )
+        #slo_request.soft = false  # TODO only available in ruby-saml >= 1.2
+        expect(slo_request.is_valid?).to eq true
+      end
+    end
+  end
+end

--- a/spec/lib/saml_idp/logout_request_builder_spec.rb
+++ b/spec/lib/saml_idp/logout_request_builder_spec.rb
@@ -16,12 +16,7 @@ module SamlIdp
     let(:saml_slo_url) { 'http://localhost:3000/saml/logout' }
     let(:name_id) { 'some_name_id' }
     let(:session_index) { 'abc123index' }
-    let(:signature_opts) do
-      {
-        reference_id: SamlIdp.config.reference_id_generator.call,
-        algorithm: OpenSSL::Digest::SHA256
-      }
-    end 
+    let(:algorithm) { OpenSSL::Digest::SHA256 }
 
     subject do
       described_class.new(
@@ -30,7 +25,7 @@ module SamlIdp
         saml_slo_url,
         name_id,
         session_index,
-        signature_opts
+        algorithm
       )
     end
 

--- a/spec/lib/saml_idp/logout_request_builder_spec.rb
+++ b/spec/lib/saml_idp/logout_request_builder_spec.rb
@@ -16,10 +16,9 @@ module SamlIdp
     let(:saml_slo_url) { 'http://localhost:3000/saml/logout' }
     let(:name_id) { 'some_name_id' }
     let(:session_index) { 'abc123index' }
-    let(:assertion_opts) do
+    let(:signature_opts) do
       {
         reference_id: SamlIdp.config.reference_id_generator.call,
-        audience_uri: 'example.com/audience',
         algorithm: OpenSSL::Digest::SHA256
       }
     end 
@@ -31,14 +30,14 @@ module SamlIdp
         saml_slo_url,
         name_id,
         session_index,
-        assertion_opts
+        signature_opts
       )
     end
 
     it "is a valid SloLogoutrequest" do
       Timecop.travel(Time.zone.local(2010, 6, 1, 13, 0, 0)) do
         slo_request = OneLogin::RubySaml::SloLogoutrequest.new(
-          Base64.strict_encode64(subject.signed),
+          subject.encoded,
           settings: saml_settings('localhost:3000')
         )
         #slo_request.soft = false  # TODO only available in ruby-saml >= 1.2

--- a/spec/lib/saml_idp/logout_response_builder_spec.rb
+++ b/spec/lib/saml_idp/logout_response_builder_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require 'saml_idp/logout_request_builder'
+require 'saml_idp/logout_response_builder'
 
 module SamlIdp
-  describe LogoutRequestBuilder do
+  describe LogoutResponseBuilder do
     before do
       Timecop.freeze(Time.local(1990))
     end
@@ -14,8 +14,7 @@ module SamlIdp
     let(:response_id) { 'some_response_id' }
     let(:issuer_uri) { 'http://example.com' }
     let(:saml_slo_url) { 'http://localhost:3000/saml/logout' }
-    let(:name_id) { 'some_name_id' }
-    let(:session_index) { 'abc123index' }
+    let(:request_id) { 'some_request_id' }
     let(:signature_opts) do
       {
         reference_id: SamlIdp.config.reference_id_generator.call,
@@ -28,20 +27,19 @@ module SamlIdp
         response_id,
         issuer_uri,
         saml_slo_url,
-        name_id,
-        session_index,
+        request_id,
         signature_opts
       )
     end
 
-    it "is a valid SloLogoutrequest" do
+    it "is a valid LogoutResponse" do
       Timecop.travel(Time.zone.local(2010, 6, 1, 13, 0, 0)) do
-        slo_request = OneLogin::RubySaml::SloLogoutrequest.new(
+        logout_response = OneLogin::RubySaml::Logoutresponse.new(
           subject.encoded,
-          settings: saml_settings('localhost:3000')
+          saml_settings('localhost:3000')
         )
-        slo_request.soft = false
-        expect(slo_request.is_valid?).to eq true
+        logout_response.soft = false
+        expect(logout_response.validate).to eq true
       end
     end
   end

--- a/spec/lib/saml_idp/logout_response_builder_spec.rb
+++ b/spec/lib/saml_idp/logout_response_builder_spec.rb
@@ -15,12 +15,7 @@ module SamlIdp
     let(:issuer_uri) { 'http://example.com' }
     let(:saml_slo_url) { 'http://localhost:3000/saml/logout' }
     let(:request_id) { 'some_request_id' }
-    let(:signature_opts) do
-      {
-        reference_id: SamlIdp.config.reference_id_generator.call,
-        algorithm: OpenSSL::Digest::SHA256
-      }
-    end 
+    let(:algorithm) { OpenSSL::Digest::SHA256 }
 
     subject do
       described_class.new(
@@ -28,7 +23,7 @@ module SamlIdp
         issuer_uri,
         saml_slo_url,
         request_id,
-        signature_opts
+        algorithm
       )
     end
 

--- a/spec/lib/saml_idp/metadata_builder_spec.rb
+++ b/spec/lib/saml_idp/metadata_builder_spec.rb
@@ -8,5 +8,12 @@ module SamlIdp
     it "signs valid xml" do
       Saml::XML::Document.parse(subject.signed).valid_signature?(Default::FINGERPRINT).should be_truthy
     end
+
+    it "includes logout element" do
+      subject.configurator.single_logout_service_post_location = 'https://example.com/saml/logout'
+      subject.fresh.should match(
+        '<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml/logout"/>'
+      )
+    end
   end
 end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -1,36 +1,76 @@
 require 'spec_helper'
 module SamlIdp
   describe Request do
-    let(:raw_request) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
-    subject { described_class.new raw_request }
+    describe "authn request" do
+      let(:raw_authn_request) { "<samlp:AuthnRequest AssertionConsumerServiceURL='http://localhost:3000/saml/consume' Destination='http://localhost:1337/saml/auth' ID='_af43d1a0-e111-0130-661a-3c0754403fdb' IssueInstant='2013-08-06T22:01:35Z' Version='2.0' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'><saml:Issuer xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>localhost:3000</saml:Issuer><samlp:NameIDPolicy AllowCreate='true' Format='urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress' xmlns:samlp='urn:oasis:names:tc:SAML:2.0:protocol'/><samlp:RequestedAuthnContext Comparison='exact'><saml:AuthnContextClassRef xmlns:saml='urn:oasis:names:tc:SAML:2.0:assertion'>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>" }
+      subject { described_class.new raw_authn_request }
 
-    it "has a valid request_id" do
-      subject.request_id.should == "_af43d1a0-e111-0130-661a-3c0754403fdb"
+      it "has a valid request_id" do
+        subject.request_id.should == "_af43d1a0-e111-0130-661a-3c0754403fdb"
+      end
+
+      it "has a valid acs_url" do
+        subject.acs_url.should == "http://localhost:3000/saml/consume"
+      end
+
+      it "has a valid service_provider" do
+        subject.service_provider.should be_a ServiceProvider
+      end
+
+      it "has a valid service_provider" do
+        subject.service_provider.should be_truthy
+      end
+
+      it "has a valid issuer" do
+        subject.issuer.should == "localhost:3000"
+      end
+
+      it "has a valid valid_signature" do
+        subject.valid_signature?.should be_truthy
+      end
+
+      it "should return acs_url for response_url" do
+        subject.response_url.should == subject.acs_url
+      end
+
+      it "is a authn request" do
+        subject.authn_request?.should == true
+      end
+
+      it "has a valid authn context" do
+        subject.requested_authn_context.should == "urn:oasis:names:tc:SAML:2.0:ac:classes:Password"
+      end
+
     end
 
-    it "has a valid acs_url" do
-      subject.acs_url.should == "http://localhost:3000/saml/consume"
-    end
+    describe "logout request" do
+      let(:raw_logout_request) { "<LogoutRequest ID='_some_response_id' Version='2.0' IssueInstant='2010-06-01T13:00:00Z' Destination='http://localhost:3000/saml/logout' xmlns='urn:oasis:names:tc:SAML:2.0:protocol'><Issuer xmlns='urn:oasis:names:tc:SAML:2.0:assertion'>http://example.com</Issuer><NameID xmlns='urn:oasis:names:tc:SAML:2.0:assertion' Format='urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'>some_name_id</NameID><SessionIndex>abc123index</SessionIndex></LogoutRequest>" }
 
-    it "has a valid service_provider" do
-      subject.service_provider.should be_a ServiceProvider
-    end
+      subject { described_class.new raw_logout_request }
 
-    it "has a valid service_provider" do
-      subject.service_provider.should be_truthy
-    end
+      it "has a valid request_id" do
+        subject.request_id.should == '_some_response_id'
+      end
 
-    it "has a valid issuer" do
-      subject.issuer.should == "localhost:3000"
-    end
+      it "should be flagged as a logout_request" do
+        subject.logout_request?.should == true
+      end
 
-    it "has a valid valid_signature" do
-      subject.valid_signature?.should be_truthy
-    end
+      it "should have a valid name_id" do
+        subject.name_id.should == 'some_name_id'
+      end
 
-    it "has a valid authn context" do
-      subject.requested_authn_context.should == "urn:oasis:names:tc:SAML:2.0:ac:classes:Password"
-    end
+      it "should have a session index" do
+        subject.session_index.should == 'abc123index'
+      end
 
+      it "should have a valid issuer" do
+        subject.issuer.should == 'http://example.com'
+      end
+
+      it "should return logout_url for response_url" do
+        subject.response_url.should == subject.logout_url
+      end
+    end
   end
 end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -45,6 +45,12 @@ module SamlIdp
         subject.requested_authn_context.should == "urn:oasis:names:tc:SAML:2.0:ac:classes:Password"
       end
 
+      it "does not permit empty issuer" do
+        raw_req = raw_authn_request.gsub('localhost:3000', '')
+        authn_request = described_class.new raw_req
+        authn_request.issuer.should_not == ''
+        authn_request.issuer.should == nil
+      end
     end
 
     describe "logout request" do

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -37,6 +37,10 @@ module SamlIdp
         subject.authn_request?.should == true
       end
 
+      it "fetches internal request" do
+        subject.request['ID'].should == subject.request_id
+      end
+
       it "has a valid authn context" do
         subject.requested_authn_context.should == "urn:oasis:names:tc:SAML:2.0:ac:classes:Password"
       end
@@ -66,6 +70,10 @@ module SamlIdp
 
       it "should have a valid issuer" do
         subject.issuer.should == 'http://example.com'
+      end
+
+      it "fetches internal request" do
+        subject.request['ID'].should == subject.request_id
       end
 
       it "should return logout_url for response_url" do

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -1,9 +1,23 @@
+require 'saml_idp/logout_request_builder'
+
 module SamlRequestMacros
 
   def make_saml_request(requested_saml_acs_url = "https://foo.example.com/saml/consume")
     auth_request = OneLogin::RubySaml::Authrequest.new
     auth_url = auth_request.create(saml_settings(requested_saml_acs_url))
     CGI.unescape(auth_url.split("=").last)
+  end
+
+  def make_saml_logout_request(requested_saml_logout_url = 'https://foo.example.com/saml/logout')
+    request_builder = SamlIdp::LogoutRequestBuilder.new(
+      'some_response_id',
+      'http://example.com',
+      requested_saml_logout_url,
+      'some_name_id',
+      'abc123index',
+      OpenSSL::Digest::SHA256
+    )
+    request_builder.encoded
   end
 
   def saml_settings(saml_acs_url = "https://foo.example.com/saml/consume")

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -16,4 +16,10 @@ module SamlRequestMacros
     settings
   end
 
+  def print_pretty_xml(xml_string)
+    doc = REXML::Document.new xml_string
+    outbuf = ""
+    doc.write(outbuf, 1)
+    puts outbuf
+  end
 end

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -116,7 +116,9 @@ module SamlIdp
 
       it "be able to validate a good response" do
         Timecop.freeze Time.parse('2012-11-28 17:55:00 UTC') do
-          response.validate!.should be_truthy
+          response.soft = false
+          skip "starfield_response fixture is not valid. missing SubjectConfirmationData element."
+          response.should be_is_valid
         end
       end
 

--- a/spec/xml_security_spec.rb
+++ b/spec/xml_security_spec.rb
@@ -116,8 +116,7 @@ module SamlIdp
 
       it "be able to validate a good response" do
         Timecop.freeze Time.parse('2012-11-28 17:55:00 UTC') do
-          response.soft = false
-          skip "starfield_response fixture is not valid. missing SubjectConfirmationData element."
+          response.stub(:validate_subject_confirmation).and_return(true)
           response.should be_is_valid
         end
       end


### PR DESCRIPTION
The newest `ruby-saml` library now supports single log out request/response. This PR adds corresponding support for that feature to IDPs.