### PR TITLE
Allow principal to assert its own attributes, rather than relying on global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ CERT
   # config.attribute_service_location = "#{base}/saml/attributes"
   # config.single_service_post_location = "#{base}/saml/auth"
 
-  # Principal is passed in when you `encode_response`
+  # Principal (e.g. User) is passed in when you `encode_response`
   #
   # config.name_id.formats # =>
   #   {                         # All 2.0
@@ -117,6 +117,28 @@ CERT
   #       persistent: -> (p) { p.id },
   #     },
   #   }
+
+  # If Principal responds to a method called `asserted_attributes`
+  # the return value of that method will be used in lieu of the
+  # attributes defined here in the global space. This allows for
+  # per-user attribute definitions.
+  #
+  ## EXAMPLE **
+  # class User
+  #   def asserted_attributes
+  #     {
+  #       phone: { getter: :phone },
+  #       email: {
+  #         getter: :email,
+  #         name_format: Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS,
+  #         name_id_format: Saml::XML::Namespaces::Formats::NameId::EMAIL_ADDRESS
+  #       }
+  #     }
+  #   end
+  # end
+  #
+  # If you have a method called `asserted_attributes` in your Principal class,
+  # there is no need to define it here in the config.
 
   # config.attributes # =>
   #   {

--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -52,9 +52,9 @@ module SamlIdp
               restriction.Audience audience_uri
             end
           end
-          if !config.attributes.nil? && !config.attributes.empty?
+          if asserted_attributes
             assertion.AttributeStatement do |attr_statement|
-              config.attributes.each do |friendly_name, attrs|
+              asserted_attributes.each do |friendly_name, attrs|
                 attrs = (attrs || {}).with_indifferent_access
                 attr_statement.Attribute Name: attrs[:name] || friendly_name,
                   NameFormat: attrs[:name_format] || Saml::XML::Namespaces::Formats::Attr::URI,
@@ -84,6 +84,15 @@ module SamlIdp
       encryptor = Encryptor.new encryption_opts
       encryptor.encrypt(raw_xml)
     end
+
+    def asserted_attributes
+      if principal.respond_to?(:asserted_attributes)
+        principal.send(:asserted_attributes)
+      elsif !config.attributes.nil? && !config.attributes.empty?
+        config.attributes
+      end
+    end
+    private :asserted_attributes
 
     def get_values_for(friendly_name, getter)
       result = nil

--- a/spec/lib/saml_idp/assertion_builder_spec.rb
+++ b/spec/lib/saml_idp/assertion_builder_spec.rb
@@ -55,6 +55,27 @@ module SamlIdp
       end
     end
 
+    describe "with principal.asserted_attributes" do
+      it "delegates attributes to principal" do
+        Principal = Struct.new(:email, :asserted_attributes)
+        principal = Principal.new('foo@example.com', { emailAddress: { getter: :email } })
+        builder = described_class.new(
+          reference_id,
+          issuer_uri,
+          principal,
+          audience_uri,
+          saml_request_id,
+          saml_acs_url,
+          algorithm,
+          authn_context_classref,
+          expiry
+        )
+        Timecop.travel(Time.zone.local(2010, 6, 1, 13, 0, 0)) do
+          builder.raw.should == "<Assertion xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_abc\" IssueInstant=\"2010-06-01T13:00:00Z\" Version=\"2.0\"><Issuer>http://sportngin.com</Issuer><Subject><NameID Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">foo@example.com</NameID><SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><SubjectConfirmationData InResponseTo=\"123\" NotOnOrAfter=\"2010-06-01T13:03:00Z\" Recipient=\"http://saml.acs.url\"></SubjectConfirmationData></SubjectConfirmation></Subject><Conditions NotBefore=\"2010-06-01T12:59:55Z\" NotOnOrAfter=\"2010-06-01T16:00:00Z\"><AudienceRestriction><Audience>http://example.com</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name=\"emailAddress\" NameFormat=\"urn:oasis:names:tc:SAML:2.0:attrname-format:uri\" FriendlyName=\"emailAddress\"><AttributeValue>foo@example.com</AttributeValue></Attribute></AttributeStatement><AuthnStatement AuthnInstant=\"2010-06-01T13:00:00Z\" SessionIndex=\"_abc\"><AuthnContext><AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</AuthnContextClassRef></AuthnContext></AuthnStatement></Assertion>"
+        end
+      end
+    end
+
     it "builds encrypted XML" do
       builder = described_class.new(
         reference_id,


### PR DESCRIPTION
New feature: if the `principal` passed to the AssertionBuilder responds to a method called `asserted_attributes` use the return value of that method rather than the global SamlIdp.config for a given SamlResponse.