### PR TITLE
Request requires issuer

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -115,10 +115,11 @@ module SamlIdp
     end
 
     def service_provider?
-      service_provider.valid?
+      service_provider && service_provider.valid?
     end
 
     def service_provider
+      return unless issuer.present?
       @_service_provider ||= ServiceProvider.new((service_provider_finder[issuer] || {}).merge(identifier: issuer))
     end
 

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -66,6 +66,7 @@ module SamlIdp
         authn_request = described_class.new raw_req
         authn_request.issuer.should_not == ''
         authn_request.issuer.should == nil
+        authn_request.valid?.should == false
       end
     end
 


### PR DESCRIPTION
**Why**: Without a valid issuer, a ServiceProvider for the Request cannot be located.
