### PR TITLE
Handle missing ContactPerson element

### DIFF
--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -128,7 +128,7 @@ module SamlIdp
     end
 
     def contact_person_document
-      @contact_person_document ||= xpath("//md:ContactPerson", md: metadata_namespace).first
+      @contact_person_document ||= (xpath("//md:ContactPerson", md: metadata_namespace).first || Saml::XML::Document.new)
     end
 
     def metadata_namespace


### PR DESCRIPTION
Why: SAML Metadata spec indicates that the ContactPerson element is an optional sequence allowing for 0 or more.

Ref: https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf line 399
