### PR TITLE
Fix ContactPerson XML Generation

### DIFF
--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -92,10 +92,11 @@ module SamlIdp
 
     def build_contact(el)
       el.ContactPerson contactType: "technical" do |contact|
-        %w[company given_name sur_name telephone mail_to_string].each do |section|
-          section_value = technical_contact.public_send(section)
-          contact.Company section_value if section_value.present?
-        end
+        contact.Company         technical_contact.company         if technical_contact.company
+        contact.GivenName       technical_contact.given_name      if technical_contact.given_name
+        contact.SurName         technical_contact.sur_name        if technical_contact.sur_name
+        contact.EmailAddress    technical_contact.mail_to_string  if technical_contact.mail_to_string
+        contact.TelephoneNumber technical_contact.telephone       if technical_contact.telephone
       end
     end
     private :build_contact

--- a/spec/lib/saml_idp/metadata_builder_spec.rb
+++ b/spec/lib/saml_idp/metadata_builder_spec.rb
@@ -15,5 +15,42 @@ module SamlIdp
         '<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml/logout"/>'
       )
     end
+
+    context "technical contact" do
+      before do
+        subject.configurator.technical_contact.company       = nil
+        subject.configurator.technical_contact.given_name    = nil
+        subject.configurator.technical_contact.sur_name      = nil
+        subject.configurator.technical_contact.telephone     = nil
+        subject.configurator.technical_contact.email_address = nil
+      end
+
+      it "all fields" do
+        subject.configurator.technical_contact.company       = "ACME Corporation"
+        subject.configurator.technical_contact.given_name    = "Road"
+        subject.configurator.technical_contact.sur_name      = "Runner"
+        subject.configurator.technical_contact.telephone     = "1-800-555-5555"
+        subject.configurator.technical_contact.email_address = "acme@example.com"
+
+        subject.fresh.should match(
+          '<ContactPerson contactType="technical"><Company>ACME Corporation</Company><GivenName>Road</GivenName><SurName>Runner</SurName><EmailAddress>mailto:acme@example.com</EmailAddress><TelephoneNumber>1-800-555-5555</TelephoneNumber></ContactPerson>'
+        )
+      end
+
+      it "no fields" do
+        subject.fresh.should match(
+          '<ContactPerson contactType="technical"></ContactPerson>'
+        )
+      end
+
+      it "just email" do
+        subject.configurator.technical_contact.email_address = "acme@example.com"
+        subject.fresh.should match(
+          '<ContactPerson contactType="technical"><EmailAddress>mailto:acme@example.com</EmailAddress></ContactPerson>'
+        )
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
The builder for ContactPerson was attempting to use meta-programming to set 5
sub-fields: company, given_name, sur_name, telephone and email_address.  However,
each of these fields was creating a "Company" node under ContactPerson, like this:

```
<ContactPerson contactType="technical">
  <Company>ACME Corporation</Company>
  <Company>Road</Company>
  <Company>Runner</Company>
  <Company>mailto:acme@example.com</Company>
  <Company>1-800-555-5555</Company>
</ContactPerson>
```

This is not valid according to the SAML spec.  When a program attempted to
validate the metadata XML document, it failed.  For our application, it meant
that occasionally we were getting errors reported.

This commit changes the ContactPerson node to be valid according to the SAML
spec.  After applying this commit, the above invalid SAML will become this:

```
<ContactPerson contactType="technical">
  <Company>ACME Corporation</Company>
  <GivenName>Road</GivenName>
  <SurName>Runner</SurName>
  <EmailAddress>mailto:acme@example.com</EmailAddress>
  <TelephoneNumber>1-800-555-5555</TelephoneNumber>
</ContactPerson
```

Section 2.3.2.2 of the SAML spec (https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf)
has the details on these fields.

I tried a few different ways to set these fields using meta-programming, but
XmlBuilder wasn't liking what I tried.  It looks like using the `tag!` in
builder, you could set tags using the same arguments from method missing, but a
mapping between the fields in metadata_builder and the XML would need to be
provided. Ultimately, I just put in the 5 fields.