### PR TITLE
Change before_filter to before_action for Rails >= 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ end
 To generate the SAML Response it uses a default X.509 certificate and secret key... which isn't so secret.
 You can find them in `SamlIdp::Default`. The X.509 certificate is valid until year 2032.
 Obviously you shouldn't use these if you intend to use this in production environments. In that case,
-within the controller set the properties `x509_certificate` and `secret_key` using a `prepend_before_filter`
+within the controller set the properties `x509_certificate` and `secret_key` using a `prepend_before_action`
 callback within the current request context or set them globally via the `SamlIdp.config.x509_certificate`
 and `SamlIdp.config.secret_key` properties.
 

--- a/app/controllers/saml_idp/idp_controller.rb
+++ b/app/controllers/saml_idp/idp_controller.rb
@@ -5,7 +5,12 @@ module SamlIdp
 
     unloadable unless Rails::VERSION::MAJOR >= 4
     protect_from_forgery
-    before_filter :validate_saml_request, only: [:new, :create]
+
+    if Rails::VERSION::MAJOR >= 4
+      before_action :validate_saml_request, only: [:new, :create]
+    else
+      before_filter :validate_saml_request, only: [:new, :create]
+    end
 
     def new
       render template: "saml_idp/idp/new"


### PR DESCRIPTION
Rails 5.0 deprecated before_filter in favor of before_action.  Rails 5.1 removes
before_filter.  before_action has been supported since Rails 4.  For Rails 3
continue to use before_filter.