### PR TITLE
Remove HTTParty as dependency, use Net::HTTP instead

### DIFF
--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -1,4 +1,5 @@
-require 'httparty'
+require 'net/http'
+require 'uri'
 require 'saml_idp/attributeable'
 require 'saml_idp/incoming_metadata'
 require 'saml_idp/persisted_metadata'
@@ -69,7 +70,7 @@ module SamlIdp
     private :fresh_incoming_metadata
 
     def request_metadata
-      metadata_url.present? ? HTTParty.get(metadata_url).body : ""
+      metadata_url.present? ? Net::HTTP.get(URI.parse(metadata_url)) : ""
     end
     private :request_metadata
   end

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -45,7 +45,6 @@ section of the README.
   s.add_dependency('activesupport', '>= 3.2')
   s.add_dependency('uuid', '~> 2.3')
   s.add_dependency('builder', '~> 3.0')
-  s.add_dependency('httparty', '~> 0.14')
   s.add_dependency('nokogiri', '>= 1.6.2')
 
   s.add_development_dependency('rake', '~> 10.4.2')


### PR DESCRIPTION
This change removes a dependency on the `HTTParty` gem. I figured a simple GET request is only needed in one place, so this private method could just use Ruby's built-in `Net::HTTP` class.