### PR TITLE
fixed render :nothing is deprecate

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -36,7 +36,7 @@ module SamlIdp
     def validate_saml_request(raw_saml_request = params[:SAMLRequest])
       decode_request(raw_saml_request)
       unless valid_saml_request?
-        if Rails::VERSION::MAJOR >= 5
+        if Rails::VERSION::MAJOR >= 4
           head :forbidden
         else
           render nothing: true, status: :forbidden

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -35,7 +35,7 @@ module SamlIdp
 
     def validate_saml_request(raw_saml_request = params[:SAMLRequest])
       decode_request(raw_saml_request)
-      render nothing: true, status: :forbidden unless valid_saml_request?
+      head :forbidden unless valid_saml_request?
     end
 
     def decode_request(raw_saml_request)

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -35,7 +35,13 @@ module SamlIdp
 
     def validate_saml_request(raw_saml_request = params[:SAMLRequest])
       decode_request(raw_saml_request)
-      head :forbidden unless valid_saml_request?
+      unless valid_saml_request?
+        if Rails::VERSION::MAJOR >= 5
+          head :forbidden
+        else
+          render nothing: true, status: :forbidden
+        end
+      end
     end
 
     def decode_request(raw_saml_request)


### PR DESCRIPTION

see: https://github.com/rails/rails/blob/1099329be081297c16b02141ec13ca6a05ff037c/actionpack/lib/action_controller/metal/rendering.rb#L101-L104

`render :nothing` is deprecated and removed in Rails 5.1.