### PR TITLE
Fix issue with invalid DataReference URI

### DIFF
--- a/lib/saml_idp/encryptor.rb
+++ b/lib/saml_idp/encryptor.rb
@@ -72,7 +72,7 @@ module SamlIdp
               cipher_data.CipherValue
             end
             enc_key.ReferenceList do |ref_list|
-              ref_list.DataReference URI: 'ED'
+              ref_list.DataReference URI: '#ED'
             end
           end
         end


### PR DESCRIPTION
See here: https://github.com/digidentity/xmlenc/blob/master/lib/xmlenc/encrypted_key.rb#L57 - corrected URI to proper format (point to ID=ED)